### PR TITLE
Bolt configuration

### DIFF
--- a/app/controllers/spree/admin/bolts_controller.rb
+++ b/app/controllers/spree/admin/bolts_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class BoltsController < Spree::Admin::BaseController
+      before_action :bolt_configuration
+
+      def show; end
+
+      private
+
+      def bolt_configuration
+        @bolt_configuration = SolidusBolt::BoltConfiguration.fetch
+      end
+    end
+  end
+end

--- a/app/controllers/spree/admin/bolts_controller.rb
+++ b/app/controllers/spree/admin/bolts_controller.rb
@@ -7,10 +7,36 @@ module Spree
 
       def show; end
 
+      def edit; end
+
+      def update
+        if @bolt_configuration.update(bolt_configuration_params)
+          flash[:success] = t('spree.admin.bolt.updated_successfully')
+          redirect_to admin_bolt_path
+        else
+          flash[:error] = @bolt_configuration.errors.full_messages.to_sentence
+          render :edit
+        end
+      end
+
       private
 
       def bolt_configuration
         @bolt_configuration = SolidusBolt::BoltConfiguration.fetch
+      end
+
+      def bolt_configuration_params
+        params
+          .require(:solidus_bolt_bolt_configuration)
+          .permit(
+            :bearer_token,
+            :environment_url,
+            :merchant_public_id,
+            :merchant_id,
+            :api_key,
+            :signing_secret,
+            :publishable_key
+          )
       end
     end
   end

--- a/app/models/solidus_bolt/bolt_configuration.rb
+++ b/app/models/solidus_bolt/bolt_configuration.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_dependency 'solidus_bolt'
+
+module SolidusBolt
+  class BoltConfiguration < ApplicationRecord
+    validate :config_can_be_created, on: :create
+
+    def self.fetch
+      first_or_create
+    end
+
+    def self.can_create?
+      count.zero?
+    end
+
+    private
+
+    def config_can_be_created
+      errors.add(:base, 'Can create only one record for this Model') unless SolidusBolt::BoltConfiguration.can_create?
+    end
+  end
+end

--- a/app/views/spree/admin/bolts/_configuration.html.erb
+++ b/app/views/spree/admin/bolts/_configuration.html.erb
@@ -1,0 +1,32 @@
+<% if @bolt_configuration.present? %>
+  <table class="index">
+    <thead>
+      <tr>
+        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:merchant_public_id) %></th>
+        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:environment_url) %></th>
+        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:created_at) %></th>
+        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:updated_at) %></th>
+        <th class="actions"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><%= @bolt_configuration.merchant_public_id %></td>
+        <td><%= @bolt_configuration.environment_url %></td>
+        <td>
+          <%= @bolt_configuration.created_at.to_s(:long) %>
+        </td>
+        <td>
+          <%= @bolt_configuration.updated_at.to_s(:long) %>
+        </td>
+        <td class="actions">
+          <% if can?(:edit, @bolt_configuration) %>
+            <%= link_to edit_btn, edit_admin_bolt_path, class: 'btn btn-primary' %>
+          <% end %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+<% else %>
+  <p> <%= t('spree.admin.bolt.configuration_not_found') %> </p>
+<% end %>

--- a/app/views/spree/admin/bolts/_form.html.erb
+++ b/app/views/spree/admin/bolts/_form.html.erb
@@ -1,0 +1,29 @@
+<%= render partial: 'spree/shared/error_messages', locals: { target: @bolt_configuration } %>
+<fieldset class="form-group no-border-bottom no-border-top">
+  <div class="row">
+    <div id="general_fields" class="col-9">
+      <div class="row">
+        <div class="col-12">
+          <%= f.label :bearer_token %>
+          <%= f.text_field :bearer_token, class: 'fullwidth'%>
+          <%= f.label :environment_url %><br />
+          <%= f.text_field :environment_url, class: 'fullwidth' %>
+          <%= f.label 'Merchant Public Id' %><br />
+          <%= f.text_field :merchant_public_id, class: 'fullwidth' %>
+          <%= f.label 'Merchant ID' %><br />
+          <%= f.text_field :merchant_id, class: 'fullwidth' %>
+          <%= f.label :api_key %><br />
+          <%= f.text_field :api_key, class: 'fullwidth' %>
+          <%= f.label :signing_secret %><br />
+          <%= f.text_field :signing_secret, class: 'fullwidth' %>
+          <%= f.label :publishable_key %><br />
+          <%= f.text_field :publishable_key, class: 'fullwidth' %>
+        </div>
+      </div>
+      <div class="row p-2 justify-content-center">
+        <%= f.submit submit_name, class: 'btn btn-primary', data: { disable_with: 'Save' } %>
+        <%= link_to 'Cancel', admin_bolt_path, class: 'button' %>
+      </div>
+    </div>
+  </div>
+</fieldset>

--- a/app/views/spree/admin/bolts/edit.html.erb
+++ b/app/views/spree/admin/bolts/edit.html.erb
@@ -1,0 +1,6 @@
+<fieldset class="no-border-bottom">
+  <legend align="center"><%= t('spree.admin.bolt.edit_configuration') %></legend>
+  <%= form_for @bolt_configuration, url: admin_bolt_path, method: :put do |f| %>
+    <%= render partial: 'form', locals: { f: f, submit_name: 'Update' } %>
+  <% end %>
+</fieldset>

--- a/app/views/spree/admin/bolts/show.html.erb
+++ b/app/views/spree/admin/bolts/show.html.erb
@@ -1,0 +1,6 @@
+<% admin_breadcrumb(plural_resource_name(SolidusBolt::BoltConfiguration)) %>
+
+<fieldset class="no-border-bottom">
+  <legend align="center"><%= t('spree.admin.bolt.configuration') %></legend>
+  <%= render partial: 'configuration', locals: { edit_btn: 'Edit' } %>
+</fieldset>

--- a/config/initializers/menu_items.rb
+++ b/config/initializers/menu_items.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Spree::Backend::Config.configure do |config|
+  config.locale = 'en'
+
+  config.menu_items << config.class::MenuItem.new(
+    [:bolt],
+    'bolt',
+    condition: -> { can?(:admin, :bolt) },
+    url: :admin_bolt_path,
+    position: 6,
+    match_path: %r{/admin/bolt/}
+  )
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,5 +8,7 @@ en:
       bolt:
         configuration: 'Bolt Configuration'
         configuration_not_found: 'No Bolt Configuration found'
+        edit_configuration: 'Edit Bolt Configuration'
+        updated_successfully: 'Bolt Configuration Updated Successfully'
       tab:
         bolt: 'Bolt'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,3 +3,10 @@
 
 en:
   hello: Hello world
+  spree:
+    admin:
+      bolt:
+        configuration: 'Bolt Configuration'
+        configuration_not_found: 'No Bolt Configuration found'
+      tab:
+        bolt: 'Bolt'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Spree::Core::Engine.routes.draw do
-  # Add your extension routes here
+  namespace :admin do
+    resource :bolt, only: [:show, :edit, :update]
+  end
 end

--- a/db/migrate/20220413063328_create_solidus_bolt_bolt_configurations.rb
+++ b/db/migrate/20220413063328_create_solidus_bolt_bolt_configurations.rb
@@ -1,0 +1,14 @@
+class CreateSolidusBoltBoltConfigurations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :solidus_bolt_bolt_configurations do |t|
+      t.string :bearer_token
+      t.string :environment_url
+      t.string :merchant_public_id
+      t.string :merchant_id
+      t.string :api_key
+      t.string :signing_secret
+      t.string :publishable_key
+      t.timestamps
+    end
+  end
+end

--- a/lib/solidus_bolt/testing_support/factories.rb
+++ b/lib/solidus_bolt/testing_support/factories.rb
@@ -1,4 +1,13 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :bolt_configuration, class: SolidusBolt::BoltConfiguration do
+    bearer_token { SecureRandom.hex }
+    environment_url { 'https:/api-sandbox.bolt.com' }
+    merchant_public_id { SecureRandom.hex }
+    merchant_id { SecureRandom.hex }
+    api_key { SecureRandom.hex }
+    signing_secret { SecureRandom.hex }
+    publishable_key { SecureRandom.hex }
+  end
 end

--- a/spec/models/solidus_bolt/bolt_configuration_spec.rb
+++ b/spec/models/solidus_bolt/bolt_configuration_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
+  let(:column_list) {
+    [
+      'id',
+      'bearer_token',
+      'environment_url',
+      'merchant_public_id',
+      'merchant_id',
+      'api_key',
+      'signing_secret',
+      'publishable_key',
+      'created_at',
+      'updated_at'
+    ]
+  }
+
+  describe '#fetch' do
+    it 'fetches the correct record' do
+      bolt_configuration = create(:bolt_configuration)
+      expect(described_class.fetch).to eq(bolt_configuration)
+    end
+
+    it 'creates a bolt record when no record is present' do
+      expect { described_class.fetch }.to change(described_class, :count).by(1)
+    end
+  end
+
+  describe '#can_create?' do
+    it 'returns true when no records are present' do
+      expect(described_class).to be_can_create
+    end
+
+    it 'returns false when records are present' do
+      create(:bolt_configuration)
+      expect(described_class).not_to be_can_create
+    end
+  end
+
+  describe 'validations' do
+    it 'raises an error when there is an existing record and a new record is created' do
+      create(:bolt_configuration)
+
+      expect {
+        create(:bolt_configuration)
+      }.to raise_error(ActiveRecord::RecordInvalid,
+        'Validation failed: Can create only one record for this Model')
+    end
+
+    it 'adds an error on :base when there is an existing record and a new record is created' do
+      create(:bolt_configuration)
+
+      expect(described_class.create.errors).to include(:base)
+    end
+
+    it 'gives a specific error message when there is an existing record and a new record is created' do
+      create(:bolt_configuration)
+
+      expect(described_class.create.errors[:base]).to include('Can create only one record for this Model')
+    end
+
+    it 'successfully creates a new record when no records are present' do
+      expect { create(:bolt_configuration) }.to change(described_class, :count).by(1)
+    end
+  end
+end

--- a/spec/requests/spree/admin/bolt_spec.rb
+++ b/spec/requests/spree/admin/bolt_spec.rb
@@ -3,6 +3,18 @@ require 'spec_helper'
 RSpec.describe "Spree::Admin::Bolts", type: :request do
   stub_authorization!
 
+  let(:bolt_configuration_params) {
+    {
+      bearer_token: SecureRandom.hex,
+      environment_url: SecureRandom.hex,
+      merchant_public_id: SecureRandom.hex,
+      merchant_id: SecureRandom.hex,
+      api_key: SecureRandom.hex,
+      signing_secret: SecureRandom.hex,
+      publishable_key: SecureRandom.hex
+    }
+  }
+
   describe "GET /show" do
     it 'returns a successful response' do
       get '/admin/bolt'
@@ -11,6 +23,49 @@ RSpec.describe "Spree::Admin::Bolts", type: :request do
 
     it 'creates a new SolidusBolt::BoltConfiguration record if no records are present' do
       expect { get '/admin/bolt' }.to change { SolidusBolt::BoltConfiguration.count }.by(1)
+    end
+  end
+
+  describe "GET /edit" do
+    let(:bolt_configuration) { create(:bolt_configuration) }
+
+    it 'returns a successful response' do
+      get '/admin/bolt/edit'
+      expect(response.status).to eq 200
+    end
+  end
+
+  describe "PUT /update" do
+    subject(:request) {
+      put '/admin/bolt', params: { solidus_bolt_bolt_configuration: bolt_configuration_params }
+    }
+
+    let(:bolt_configuration) { create(:bolt_configuration) }
+
+    it 'successfully redirects' do
+      request
+      expect(response.status).to eq 302
+    end
+
+    it 'redirects to index' do
+      request
+      expect(response).to redirect_to '/admin/bolt'
+    end
+
+    it 'successfully updates the bolt configuration' do
+      request
+
+      updated_attributes = SolidusBolt::BoltConfiguration.fetch.attributes.slice(
+        'bearer_token',
+        'environment_url',
+        'merchant_public_id',
+        'merchant_id',
+        'api_key',
+        'signing_secret',
+        'publishable_key'
+      )
+
+      expect(updated_attributes).to eq(bolt_configuration_params.deep_stringify_keys)
     end
   end
 end

--- a/spec/requests/spree/admin/bolt_spec.rb
+++ b/spec/requests/spree/admin/bolt_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe "Spree::Admin::Bolts", type: :request do
+  stub_authorization!
+
+  describe "GET /show" do
+    it 'returns a successful response' do
+      get '/admin/bolt'
+      expect(response.status).to eq 200
+    end
+
+    it 'creates a new SolidusBolt::BoltConfiguration record if no records are present' do
+      expect { get '/admin/bolt' }.to change { SolidusBolt::BoltConfiguration.count }.by(1)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ ENV['RAILS_ENV'] = 'test'
 
 # Run Coverage report
 require 'solidus_dev_support/rspec/coverage'
+require 'pry'
 
 # Create the dummy app if it's still missing.
 dummy_env = "#{__dir__}/dummy/config/environment.rb"


### PR DESCRIPTION
This PR aims to create the framework and support to store a Bolt Configuration on the database.

Features of this PR
1. New model and table created to store the Bolt Configuration
2. New Menu Item on the Admin Panel for Bolt
3. Allows the admin user to set `api_key`, `signing_secret`, `publishable_key`, `merchant_id`, `merchant_public_id`, `bearer_token`, `environment_url`