### PR TITLE
Fix Issue with environment_url in bolt_configuration factory

### DIFF
--- a/lib/solidus_bolt/testing_support/factories.rb
+++ b/lib/solidus_bolt/testing_support/factories.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :bolt_configuration, class: SolidusBolt::BoltConfiguration do
     bearer_token { SecureRandom.hex }
-    environment_url { 'https:/api-sandbox.bolt.com' }
+    environment_url { 'https://api-sandbox.bolt.com' }
     merchant_public_id { SecureRandom.hex }
     merchant_id { SecureRandom.hex }
     api_key { SecureRandom.hex }


### PR DESCRIPTION
This PR fixes an issue with the `environment_url` in the factory for the `bolt_configuration`.

The issue was an incorrect value in the `environment_url` field.

This has now been changed from `https:/api-sandbox.bolt.com` which was incorrect to `https://api-sandbox.bolt.com` which is the correct value