### PR TITLE
Better UX For BoltConfiguration

### DIFF
--- a/app/controllers/spree/admin/bolts_controller.rb
+++ b/app/controllers/spree/admin/bolts_controller.rb
@@ -30,7 +30,7 @@ module Spree
           .require(:solidus_bolt_bolt_configuration)
           .permit(
             :bearer_token,
-            :environment_url,
+            :environment,
             :merchant_public_id,
             :merchant_id,
             :api_key,

--- a/app/models/solidus_bolt/bolt_configuration.rb
+++ b/app/models/solidus_bolt/bolt_configuration.rb
@@ -6,6 +6,8 @@ module SolidusBolt
   class BoltConfiguration < ApplicationRecord
     REGISTER_URL = 'https://merchant.bolt.com/register'
 
+    enum environment: { production: 0, sandbox: 1, staging: 2 }
+
     validate :config_can_be_created, on: :create
 
     def self.fetch
@@ -21,6 +23,14 @@ module SolidusBolt
 
       fetch.attributes.all? do |attr, val|
         whitelist.include?(attr) || val.blank?
+      end
+    end
+
+    def environment_url
+      case BoltConfiguration.environments[environment]
+      when 0 then 'https://api.bolt.com'
+      when 1 then 'https://api-sandbox.bolt.com'
+      when 2 then 'https://api-staging.bolt.com'
       end
     end
 

--- a/app/views/spree/admin/bolts/_configuration.html.erb
+++ b/app/views/spree/admin/bolts/_configuration.html.erb
@@ -3,7 +3,7 @@
     <thead>
       <tr>
         <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:merchant_public_id) %></th>
-        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:environment_url) %></th>
+        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:environment) %></th>
         <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:created_at) %></th>
         <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:updated_at) %></th>
         <th class="actions"></th>
@@ -12,7 +12,7 @@
     <tbody>
       <tr>
         <td><%= @bolt_configuration.merchant_public_id %></td>
-        <td><%= @bolt_configuration.environment_url %></td>
+        <td><%= @bolt_configuration.environment %></td>
         <td>
           <%= @bolt_configuration.created_at.to_s(:long) %>
         </td>

--- a/app/views/spree/admin/bolts/_form.html.erb
+++ b/app/views/spree/admin/bolts/_form.html.erb
@@ -4,10 +4,10 @@
     <div id="general_fields" class="col-9">
       <div class="row">
         <div class="col-12">
+          <%= f.label :environment %>
+          <%= f.select :environment, %w[production sandbox staging] %><br />
           <%= f.label :bearer_token %>
           <%= f.text_field :bearer_token, class: 'fullwidth'%>
-          <%= f.label :environment_url %><br />
-          <%= f.text_field :environment_url, class: 'fullwidth' %>
           <%= f.label 'Merchant Public Id' %><br />
           <%= f.text_field :merchant_public_id, class: 'fullwidth' %>
           <%= f.label 'Merchant ID' %><br />

--- a/db/migrate/20220502005041_swap_url_for_env_boolean_in_bolt_configuration.rb
+++ b/db/migrate/20220502005041_swap_url_for_env_boolean_in_bolt_configuration.rb
@@ -1,0 +1,6 @@
+class SwapUrlForEnvBooleanInBoltConfiguration < ActiveRecord::Migration[6.1]
+  def change
+    add_column :solidus_bolt_bolt_configurations, :environment, :integer
+    remove_column :solidus_bolt_bolt_configurations, :environment_url, :string
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@
 solidus_bolt_configuration = SolidusBolt::BoltConfiguration.fetch
 
 solidus_bolt_configuration.bearer_token = ENV['BOLT_BEARER_TOKEN']
-solidus_bolt_configuration.environment_url = ENV['BOLT_ENVIRONMENT_URL']
+solidus_bolt_configuration.environment = ENV['BOLT_ENVIRONMENT']
 solidus_bolt_configuration.merchant_public_id = ENV['BOLT_MERCHANT_PUBLIC_ID']
 solidus_bolt_configuration.merchant_id = ENV['BOLT_MERCHANT_ID']
 solidus_bolt_configuration.api_key = ENV['BOLT_API_KEY']

--- a/lib/solidus_bolt/testing_support/factories.rb
+++ b/lib/solidus_bolt/testing_support/factories.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :bolt_configuration, class: SolidusBolt::BoltConfiguration do
     bearer_token { SecureRandom.hex }
-    environment_url { 'https://api-sandbox.bolt.com' }
+    environment { 'sandbox' }
     merchant_public_id { SecureRandom.hex }
     merchant_id { SecureRandom.hex }
     api_key { SecureRandom.hex }

--- a/spec/models/solidus_bolt/bolt_configuration_spec.rb
+++ b/spec/models/solidus_bolt/bolt_configuration_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     [
       'id',
       'bearer_token',
-      'environment_url',
+      'environment',
       'merchant_public_id',
       'merchant_id',
       'api_key',
@@ -48,7 +48,7 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
       create(
         :bolt_configuration,
         bearer_token: '',
-        environment_url: '',
+        environment: nil,
         merchant_public_id: '',
         merchant_id: '',
         api_key: '',
@@ -61,6 +61,26 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     it 'is false for a record with data' do
       create(:bolt_configuration)
       expect(described_class).not_to be_config_empty
+    end
+  end
+
+  describe '#environment_url' do
+    context 'when production envornment' do
+      let(:config) { create(:bolt_configuration, environment: 'production') }
+
+      it { expect(config.environment_url).to eq('https://api.bolt.com') }
+    end
+
+    context 'when sandbox envornment' do
+      let(:config) { create(:bolt_configuration) }
+
+      it { expect(config.environment_url).to eq('https://api-sandbox.bolt.com') }
+    end
+
+    context 'when staging envornment' do
+      let(:config) { create(:bolt_configuration, environment: 'staging') }
+
+      it { expect(config.environment_url).to eq('https://api-staging.bolt.com') }
     end
   end
 

--- a/spec/models/solidus_bolt/bolt_configuration_spec.rb
+++ b/spec/models/solidus_bolt/bolt_configuration_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     ]
   }
 
-  describe '#fetch' do
+  describe '.fetch' do
     it 'fetches the correct record' do
       bolt_configuration = create(:bolt_configuration)
       expect(described_class.fetch).to eq(bolt_configuration)
@@ -27,7 +27,7 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     end
   end
 
-  describe '#can_create?' do
+  describe '.can_create?' do
     it 'returns true when no records are present' do
       expect(described_class).to be_can_create
     end
@@ -38,7 +38,7 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     end
   end
 
-  describe '#config_empty?' do
+  describe '.config_empty?' do
     it 'is true for a new empty record' do
       described_class.fetch
       expect(described_class).to be_config_empty

--- a/spec/requests/spree/admin/bolt_spec.rb
+++ b/spec/requests/spree/admin/bolt_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Spree::Admin::Bolts", type: :request do
   let(:bolt_configuration_params) {
     {
       bearer_token: SecureRandom.hex,
-      environment_url: SecureRandom.hex,
+      environment: 'sandbox',
       merchant_public_id: SecureRandom.hex,
       merchant_id: SecureRandom.hex,
       api_key: SecureRandom.hex,
@@ -57,7 +57,7 @@ RSpec.describe "Spree::Admin::Bolts", type: :request do
 
       updated_attributes = SolidusBolt::BoltConfiguration.fetch.attributes.slice(
         'bearer_token',
-        'environment_url',
+        'environment',
         'merchant_public_id',
         'merchant_id',
         'api_key',

--- a/spec/support/bolt_configuration.rb
+++ b/spec/support/bolt_configuration.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
     solidus_bolt_configuration = SolidusBolt::BoltConfiguration.fetch
 
     solidus_bolt_configuration.bearer_token = ENV['BOLT_BEARER_TOKEN']
-    solidus_bolt_configuration.environment_url = 'https://api-sandbox.bolt.com'
+    solidus_bolt_configuration.environment = 'sandbox'
     solidus_bolt_configuration.merchant_public_id = ENV['BOLT_MERCHANT_PUBLIC_ID']
     solidus_bolt_configuration.merchant_id = ENV['BOLT_MERCHANT_ID']
     solidus_bolt_configuration.api_key = ENV['BOLT_API_KEY']


### PR DESCRIPTION
Asking users to copy-paste a url is bad UX, instead we should ask them to decide between test and production environment and handle the related urls with the backend logic.

This will become a greater issue down the line as the url to display iframes is different from the one to making API calls, meaning that without this change we would ask for even more copy-pasted urls.