### PR TITLE
Oauth Token Service

### DIFF
--- a/app/services/solidus_bolt/base_service.rb
+++ b/app/services/solidus_bolt/base_service.rb
@@ -19,7 +19,13 @@ module SolidusBolt
     def handle_result(result)
       return result.parsed_response if result.success?
 
-      raise ServerError, result['errors'].map { |e| e['message'] }.join(', ')
+      raise ServerError, error_message(result)
+    end
+
+    def error_message(result)
+      return result['errors'].map { |e| e['message'] }.join(', ') if result['errors']
+
+      "#{result['error']}: #{result['error_description']}"
     end
 
     def api_base_url
@@ -40,6 +46,10 @@ module SolidusBolt
 
     def publishable_key
       @config.publishable_key
+    end
+
+    def api_key
+      @config.api_key
     end
   end
 end

--- a/app/services/solidus_bolt/oauth/token_service.rb
+++ b/app/services/solidus_bolt/oauth/token_service.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module Oauth
+    class TokenService < SolidusBolt::BaseService
+      attr_reader :authorization_code, :scope
+
+      def initialize(authorization_code:, scope:)
+        @authorization_code = authorization_code
+        @scope = scope
+        super
+      end
+
+      def call
+        token
+      end
+
+      private
+
+      def token
+        options = build_options
+        handle_result(
+          HTTParty.post(
+            "#{api_base_url}/#{api_version}/oauth/token",
+            options
+          )
+        )
+      end
+
+      def build_options
+        {
+          body: {
+            grant_type: 'authorization_code',
+            code: authorization_code,
+            scope: scope,
+            client_id: publishable_key,
+            client_secret: api_key
+          }
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Oauth_TokenService/_call/makes_the_API_call.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Oauth_TokenService/_call/makes_the_API_call.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-sandbox.bolt.com/v1/oauth/token
+    body:
+      encoding: UTF-8
+      string: grant_type=authorization_code&code=Bolt%20Authorization%20Code&scope=openid%20bolt.account.manage&client_id=<PUBLISHABLE_KEY>&client_secret=<API_KEY>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Fri, 06 May 2022 04:07:06 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '285'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-store
+      Pragma:
+      - no-cache
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=060c417d-4f67-4b36-bf43-94ad1c62a96d; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Error-Code:
+      - '0'
+      X-Bolt-Trace-Id:
+      - Root=1-62749eea-4f3fe59a5770100c431b0442
+      X-Device-Id:
+      - 00d52d87772089f7901040d42ba5aa09c750b26ed688a8c25f07e35defbd2310
+      X-Envoy-Upstream-Service-Time:
+      - '32'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"error":"invalid_grant","error_description":"The provided authorization
+        grant (e.g., authorization code, resource owner credentials) or refresh token
+        is invalid, expired, revoked, does not match the redirection URI used in the
+        authorization request, or was issued to another client."}'
+  recorded_at: Fri, 06 May 2022 04:07:06 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/solidus_bolt/oauth/token_service_spec.rb
+++ b/spec/services/solidus_bolt/oauth/token_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::Oauth::TokenService, :vcr, :bolt_configuration do
+  subject(:api) {
+    described_class.new(authorization_code: 'Bolt Authorization Code', scope: 'openid bolt.account.manage')
+  }
+
+  describe '#call', vcr: true do
+    it 'makes the API call' do
+      expect { api.call }.to raise_error SolidusBolt::ServerError
+    end
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -14,6 +14,9 @@ VCR.configure do |config|
     interaction.request.headers['X-Publishable-Key']&.first
   end
 
+  config.filter_sensitive_data('<PUBLISHABLE_KEY>') { SolidusBolt::BoltConfiguration.fetch.publishable_key }
+  config.filter_sensitive_data('<API_KEY>') { SolidusBolt::BoltConfiguration.fetch.api_key }
+
   # Let's you set default VCR record mode with VCR_RECORDE_MODE=all for re-recording
   # episodes. :once is VCR default
   record_mode = ENV.fetch('VCR_RECORD_MODE', :once).to_sym


### PR DESCRIPTION
This PR adds the `SolidusBolt::Oauth::TokenService`.

This service takes in the `authorization_code` and scope returned from the `authorize` call from the `authorizationComponent` and exchanges it for an access_token from Bolt.

The `access_token` should allow access to the shopper’s Bolt Account information.

The response from the service also includes an `id_token` which includes the necessary information to perform an SSO login.