### PR TITLE
Update Ruby version to 3.1.1

### DIFF
--- a/app/services/solidus_bolt/base_service.rb
+++ b/app/services/solidus_bolt/base_service.rb
@@ -10,8 +10,8 @@ module SolidusBolt
       raise NotImplementedError
     end
 
-    def self.call(*args)
-      new(*args).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     private

--- a/solidus_bolt.gemspec
+++ b/solidus_bolt.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/nebulab/solidus_bolt'
   spec.metadata['changelog_uri'] = 'https://github.com/nebulab/solidus_bolt/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0', '< 3.2')
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'httparty'
+  spec.add_dependency 'net-smtp'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_support', '~> 0.5'
   spec.add_dependency 'tweetnacl'


### PR DESCRIPTION
Due to changes to solidus_core CircleCI now runs on Ruby 3.1 which
breaks automated tests. This commit brings the payment extension up to
date with the expectations and modifies the SolidusBolt::BaseService to
be compliant with expected syntax.
