### PR TITLE
Void payment via Gateway

### DIFF
--- a/app/decorators/models/solidus_bolt/payment_decorator.rb
+++ b/app/decorators/models/solidus_bolt/payment_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module PaymentDecorator
+    def can_void?
+      super && state == 'pending'
+    end
+
+    Spree::Payment.prepend(self)
+  end
+end

--- a/spec/decorators/models/solidus_bolt/payment_decorator_spec.rb
+++ b/spec/decorators/models/solidus_bolt/payment_decorator_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::PaymentDecorator do
+  describe '#can_void?' do
+    [
+      'checkout',
+      'completed',
+      'processing',
+      'failed',
+      'void',
+      'invalid'
+    ].each do |state|
+      let(:payment) { Spree::Payment.new(state: state) }
+
+      context "when payment state is #{state}" do
+        it 'return false' do
+          expect(payment.can_void?).to eq false
+        end
+      end
+    end
+
+    context "when payment state is pending" do
+      let(:payment) { Spree::Payment.new(state: 'pending') }
+
+      it 'return true' do
+        expect(payment.can_void?).to eq true
+      end
+    end
+  end
+end

--- a/spec/models/solidus_bolt/gateway_spec.rb
+++ b/spec/models/solidus_bolt/gateway_spec.rb
@@ -54,8 +54,25 @@ RSpec.describe SolidusBolt::Gateway, type: :model do
   end
 
   describe '#void' do
-    it 'raises NotImplementedError' do
-      expect { described_class.new.void(nil, nil) }.to raise_error(NotImplementedError)
+    subject(:void) { described_class.new.void(response_code, gateway_options) }
+
+    let(:response_code) { 'the_amazing_spiderman' }
+
+    let(:response) {
+      { 'id' => "id-#{response_code}", 'reference' => response_code }
+    }
+
+    before do
+      allow(SolidusBolt::Transactions::VoidService).to receive(:call).and_return(response)
+      allow(SolidusBolt::Transactions::DetailService).to receive(:call).and_return(response)
+    end
+
+    it 'returns an active merchant billing response' do
+      expect(void).to be_an_instance_of(ActiveMerchant::Billing::Response)
+    end
+
+    it 'stores the transaction reference as response code' do
+      expect(void.authorization).to eq response_code
     end
   end
 


### PR DESCRIPTION
This PR implements the `void` method in the Gateway for Bolt.

The `void` method calls the `SolidusBolt::Transactions::VoidService` to make the Bolt Void API Call and stores the response reference for future steps.