### PR TITLE
Account Detail Service

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ factories along with this extension's factories using this statement:
 SolidusDevSupport::TestingSupport::Factories.load_for(SolidusBolt::Engine)
 ```
 
+#### Special Tests
+
+A few tests in the test suite require some additional steps to execute successfully when they are modified. These are listed below along with the steps needed to execute these tests.
+
+- `/spec/services/solidus_bolt/accounts/detail_service_spec.rb`
+This test requires a valid `bolt_access_token` to execute successfully when modified.
+Follow the steps below to get a `bolt_access_token`.
+  1. Login as a User using a Bolt Account.
+  2. Put a `binding.pry` on any view.
+  3. Print `session['bolt_access_token']` in the pry console.
+  4. Copy the result and set the value of the environment variable `BOLT_ACCESS_TOKEN` to this result.
+
 ### Running the sandbox
 
 To run this extension in a sandboxed Solidus application, you can run `bin/sandbox`. The path for

--- a/app/services/solidus_bolt/accounts/detail_service.rb
+++ b/app/services/solidus_bolt/accounts/detail_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module Accounts
+    class DetailService < SolidusBolt::BaseService
+      attr_reader :access_token
+
+      def initialize(access_token:)
+        @access_token = access_token
+        super
+      end
+
+      def call
+        detail
+      end
+
+      private
+
+      def detail
+        options = build_options
+        handle_result(
+          HTTParty.get(
+            "#{api_base_url}/#{api_version}/account",
+            options
+          )
+        )
+      end
+
+      def build_options
+        {
+          headers: {
+            'Authorization' => "Bearer #{access_token}",
+          }.merge(authentication_header)
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_correct_access_token/receives_a_successful_response.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_correct_access_token/receives_a_successful_response.yml
@@ -1,0 +1,159 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer qIm3IJy_-H0ytdEUItALvGR_rZPY6f_u4FMgUTAB__0.2bGRspapuPrN6IampksAE7o6l8V7u340dH76-3cRVAg
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 16 May 2022 11:19:10 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '200'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=28d10125-b5e5-4ceb-9f5d-5449f090c431; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-6282332d-4e3955be79dd8a333f1b96d6
+      X-Device-Id:
+      - ad1ce04b46593e54d09c6ae8b2abce20b1c051fc0920ac71d3a5a5c683ecbbe7
+      X-Envoy-Upstream-Service-Time:
+      - '87'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
+        Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
+  recorded_at: Mon, 16 May 2022 11:19:10 GMT
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer qIm3IJy_-H0ytdEUItALvGR_rZPY6f_u4FMgUTAB__0.2bGRspapuPrN6IampksAE7o6l8V7u340dH76-3cRVAg
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 16 May 2022 11:19:11 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '200'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=fbfaf20b-ecd6-47e1-baed-b800391445a2; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-6282332f-3bb50b394279c2675556fe9d
+      X-Device-Id:
+      - 600e92081ff879d39a8b5e054612917b034294e1da40aba3feb9d1ee07d29d38
+      X-Envoy-Upstream-Service-Time:
+      - '16'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
+        Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
+  recorded_at: Mon, 16 May 2022 11:19:11 GMT
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer qIm3IJy_-H0ytdEUItALvGR_rZPY6f_u4FMgUTAB__0.2bGRspapuPrN6IampksAE7o6l8V7u340dH76-3cRVAg
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 16 May 2022 11:19:12 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '200'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=951e83bc-333a-4840-b7f2-f0c61d25a02a; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62823330-6f8d31f847b8a289644d8450
+      X-Device-Id:
+      - 69040285b6a58d0aa7236ff3f82b6f509c96331db29c4c2ad34ad2d7e2f8fed7
+      X-Envoy-Upstream-Service-Time:
+      - '57'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
+        Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
+  recorded_at: Mon, 16 May 2022 11:19:12 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_correct_access_token/receives_a_successful_response.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_correct_access_token/receives_a_successful_response.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer qIm3IJy_-H0ytdEUItALvGR_rZPY6f_u4FMgUTAB__0.2bGRspapuPrN6IampksAE7o6l8V7u340dH76-3cRVAg
+      - "<BEARER AUTHORIZATION>"
       X-Api-Key:
       - "<API_KEY>"
       Accept-Encoding:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 May 2022 11:19:10 GMT
+      - Mon, 16 May 2022 11:37:30 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -33,25 +33,25 @@ http_interactions:
       Public-Key-Pins-Report-Only:
       - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
       Set-Cookie:
-      - trk=28d10125-b5e5-4ceb-9f5d-5449f090c431; Path=/; Max-Age=31536000; HttpOnly;
+      - trk=634156b0-0a32-48b3-9d33-cbac14c957e5; Path=/; Max-Age=31536000; HttpOnly;
         Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Bolt-Api-Version:
       - '2022-01-01'
       X-Bolt-Trace-Id:
-      - Root=1-6282332d-4e3955be79dd8a333f1b96d6
+      - Root=1-6282377a-36a07b7a13d19ded15b028e2
       X-Device-Id:
-      - ad1ce04b46593e54d09c6ae8b2abce20b1c051fc0920ac71d3a5a5c683ecbbe7
+      - 820897c02a7a1d3d2931f58c098dd0b2d39d65541f265f23b8f39b4f1573c3c2
       X-Envoy-Upstream-Service-Time:
-      - '87'
+      - '18'
       Server:
       - envoy
     body:
       encoding: UTF-8
       string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
         Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
-  recorded_at: Mon, 16 May 2022 11:19:10 GMT
+  recorded_at: Mon, 16 May 2022 11:37:30 GMT
 - request:
     method: get
     uri: https://api-sandbox.bolt.com/v1/account
@@ -60,7 +60,7 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer qIm3IJy_-H0ytdEUItALvGR_rZPY6f_u4FMgUTAB__0.2bGRspapuPrN6IampksAE7o6l8V7u340dH76-3cRVAg
+      - "<BEARER AUTHORIZATION>"
       X-Api-Key:
       - "<API_KEY>"
       Accept-Encoding:
@@ -75,7 +75,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 May 2022 11:19:11 GMT
+      - Mon, 16 May 2022 11:37:32 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -85,25 +85,25 @@ http_interactions:
       Public-Key-Pins-Report-Only:
       - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
       Set-Cookie:
-      - trk=fbfaf20b-ecd6-47e1-baed-b800391445a2; Path=/; Max-Age=31536000; HttpOnly;
+      - trk=00cccd4a-e55b-42f7-aec4-c5505d7f9ea8; Path=/; Max-Age=31536000; HttpOnly;
         Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Bolt-Api-Version:
       - '2022-01-01'
       X-Bolt-Trace-Id:
-      - Root=1-6282332f-3bb50b394279c2675556fe9d
+      - Root=1-6282377c-3e3afdfd4f35e7472e28fa49
       X-Device-Id:
-      - 600e92081ff879d39a8b5e054612917b034294e1da40aba3feb9d1ee07d29d38
+      - 8380fe1a24237cc9dc98d4c9c000e04ce94c19bf9301bed7a389b01e6e62d3c5
       X-Envoy-Upstream-Service-Time:
-      - '16'
+      - '54'
       Server:
       - envoy
     body:
       encoding: UTF-8
       string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
         Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
-  recorded_at: Mon, 16 May 2022 11:19:11 GMT
+  recorded_at: Mon, 16 May 2022 11:37:32 GMT
 - request:
     method: get
     uri: https://api-sandbox.bolt.com/v1/account
@@ -112,7 +112,7 @@ http_interactions:
       string: ''
     headers:
       Authorization:
-      - Bearer qIm3IJy_-H0ytdEUItALvGR_rZPY6f_u4FMgUTAB__0.2bGRspapuPrN6IampksAE7o6l8V7u340dH76-3cRVAg
+      - "<BEARER AUTHORIZATION>"
       X-Api-Key:
       - "<API_KEY>"
       Accept-Encoding:
@@ -127,7 +127,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 May 2022 11:19:12 GMT
+      - Mon, 16 May 2022 11:37:33 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -137,23 +137,23 @@ http_interactions:
       Public-Key-Pins-Report-Only:
       - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
       Set-Cookie:
-      - trk=951e83bc-333a-4840-b7f2-f0c61d25a02a; Path=/; Max-Age=31536000; HttpOnly;
+      - trk=9f0458e7-edae-4fa4-ac20-bf8a44f1dfae; Path=/; Max-Age=31536000; HttpOnly;
         Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Bolt-Api-Version:
       - '2022-01-01'
       X-Bolt-Trace-Id:
-      - Root=1-62823330-6f8d31f847b8a289644d8450
+      - Root=1-6282377d-5c4c52465481e9c10a25cfeb
       X-Device-Id:
-      - 69040285b6a58d0aa7236ff3f82b6f509c96331db29c4c2ad34ad2d7e2f8fed7
+      - e21efc8f82b9628132d556ce7033ae227bcb36a899e46868b297a983fa2fae2a
       X-Envoy-Upstream-Service-Time:
-      - '57'
+      - '54'
       Server:
       - envoy
     body:
       encoding: UTF-8
       string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
         Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
-  recorded_at: Mon, 16 May 2022 11:19:12 GMT
+  recorded_at: Mon, 16 May 2022 11:37:33 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_wrong_access_token/gives_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_wrong_access_token/gives_an_error.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - Bearer Bolt Access Token
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Mon, 16 May 2022 11:17:38 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '89'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=68477a42-2b3b-4ce2-b041-fbf01adc05ec; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-628232d2-74004fc24c6d262b73fde049
+      X-Device-Id:
+      - 50d06b486ee79807b82cc001f80fd4fe6fc68ff04f137679453a319e7658fd99
+      X-Envoy-Upstream-Service-Time:
+      - '12'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"result":{"success":false},"errors":[{"code":18,"message":"This action
+        is forbidden."}]}'
+  recorded_at: Mon, 16 May 2022 11:17:38 GMT
+recorded_with: VCR 6.0.0

--- a/spec/services/solidus_bolt/accounts/detail_service_spec.rb
+++ b/spec/services/solidus_bolt/accounts/detail_service_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::Accounts::DetailService, :vcr, :bolt_configuration do
+  describe '#call', vcr: true do
+    subject(:api) { described_class.new(access_token: access_token) }
+
+    context 'with wrong access_token' do
+      let(:access_token) { 'Bolt Access Token' }
+
+      it 'gives an error' do
+        expect{ api.call }.to raise_error(SolidusBolt::ServerError, 'This action is forbidden.')
+      end
+    end
+
+    context 'with correct access_token' do
+      let(:access_token) { ENV['BOLT_ACCESS_TOKEN'] }
+
+      it 'receives a successful response' do
+        expect(api.call).to match hash_including('profile')
+        expect(api.call).to match hash_including('addresses')
+        expect(api.call).to match hash_including('payment_methods')
+      end
+    end
+  end
+end
+
+# This spec depends on the bolt_access_token that needs to be generated manually
+# and added to the environment variable BOLT_ACCESS_TOKEN.
+# Generate a new access token by logging into an existing user bolt account on
+# development environment and copying the token from the session['bolt_access_token'] key.

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -14,6 +14,10 @@ VCR.configure do |config|
     interaction.request.headers['X-Publishable-Key']&.first
   end
 
+  config.filter_sensitive_data('<BEARER AUTHORIZATION>') do |interaction|
+    interaction.request.headers['Authorization']&.first
+  end
+
   config.filter_sensitive_data('<PUBLISHABLE_KEY>') { SolidusBolt::BoltConfiguration.fetch.publishable_key }
   config.filter_sensitive_data('<API_KEY>') { SolidusBolt::BoltConfiguration.fetch.api_key }
 


### PR DESCRIPTION
This PR adds the `SolidusBolt::Accounts::DetailService` API Object.

This object inherits from the `SolidusBolt::Base` Service Object and allows to call the `/account` api for Bolt.

This requires a single argument which is an `access_token`.

Bolt API DOCS reference: https://help.bolt.com/api-bolt/#tag/Account/operation/GetAccountDetails