### PR TITLE
Add PaymentSource to Spree::User

### DIFF
--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_payment_source.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_payment_source.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module SpreeCheckoutController
+    module RefreshBoltPaymentSource
+      def before_payment
+        SolidusBolt::Users::SyncPaymentSourcesService.call(
+          user: spree_current_user, access_token: session[:bolt_access_token]
+        )
+
+        super
+      end
+
+      Spree::CheckoutController.prepend self
+    end
+  end
+end

--- a/app/decorators/models/solidus_bolt/user_decorator.rb
+++ b/app/decorators/models/solidus_bolt/user_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module UserDecorator
+    def self.prepended(base)
+      base.has_many :bolt_payment_sources, class_name: 'SolidusBolt::PaymentSource'
+    end
+
+    Spree::User.prepend(self)
+  end
+end

--- a/app/models/solidus_bolt/payment_source.rb
+++ b/app/models/solidus_bolt/payment_source.rb
@@ -4,5 +4,6 @@ require_dependency 'solidus_bolt'
 
 module SolidusBolt
   class PaymentSource < SolidusSupport.payment_source_parent_class
+    belongs_to :user, class_name: 'Spree::User', optional: true
   end
 end

--- a/app/services/solidus_bolt/users/sync_payment_sources_service.rb
+++ b/app/services/solidus_bolt/users/sync_payment_sources_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module Users
+    class SyncPaymentSourcesService < SolidusBolt::BaseService
+      attr_reader :user, :access_token
+
+      def initialize(user:, access_token:)
+        @user = user
+        @access_token = access_token
+        super
+      end
+
+      def call
+        return if user.nil? || access_token.nil?
+
+        payment_methods.each do |payment_method|
+          add_payment_source(payment_method)
+        end
+      end
+
+      private
+
+      def user_info
+        @user_info ||= Accounts::DetailService.call(access_token: access_token)
+      end
+
+      def payment_methods
+        user_info['payment_methods']
+      end
+
+      def add_payment_source(payment_method)
+        # format of card_expiration: '2022-04'
+        card_expiration = "#{payment_method['exp_year']}-#{payment_method['exp_month'].to_s.rjust(2, '0')}"
+        SolidusBolt::PaymentSource.find_or_create_by!(
+          user_id: user.id,
+          card_last4: payment_method['last4'],
+          card_expiration: card_expiration,
+          card_id: payment_method['id']
+        )
+      end
+    end
+  end
+end

--- a/db/migrate/20220519233043_add_user_to_solidus_bolt_payment_source.rb
+++ b/db/migrate/20220519233043_add_user_to_solidus_bolt_payment_source.rb
@@ -1,0 +1,5 @@
+class AddUserToSolidusBoltPaymentSource < ActiveRecord::Migration[6.1]
+  def change
+    add_column :solidus_bolt_payment_sources, :user_id, :integer
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_correct_access_token/receives_a_successful_response.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_DetailService/_call/with_correct_access_token/receives_a_successful_response.yml
@@ -23,137 +23,33 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 16 May 2022 11:37:30 GMT
+      - Fri, 20 May 2022 00:52:42 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '200'
+      - '301'
       Connection:
       - keep-alive
       Public-Key-Pins-Report-Only:
       - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
       Set-Cookie:
-      - trk=634156b0-0a32-48b3-9d33-cbac14c957e5; Path=/; Max-Age=31536000; HttpOnly;
+      - trk=9f69895b-8b34-4f62-a508-f09650d5c4d2; Path=/; Max-Age=31536000; HttpOnly;
         Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Bolt-Api-Version:
       - '2022-01-01'
       X-Bolt-Trace-Id:
-      - Root=1-6282377a-36a07b7a13d19ded15b028e2
+      - Root=1-6286e65a-60b62fbb00698d3507bec285
       X-Device-Id:
-      - 820897c02a7a1d3d2931f58c098dd0b2d39d65541f265f23b8f39b4f1573c3c2
+      - b14d37786ac06e9df121d6418689d1ee7f8472e4116cd32892f2e29ad103bc71
       X-Envoy-Upstream-Service-Time:
-      - '18'
+      - '73'
       Server:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
-        Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
-  recorded_at: Mon, 16 May 2022 11:37:30 GMT
-- request:
-    method: get
-    uri: https://api-sandbox.bolt.com/v1/account
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - "<BEARER AUTHORIZATION>"
-      X-Api-Key:
-      - "<API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 16 May 2022 11:37:32 GMT
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '200'
-      Connection:
-      - keep-alive
-      Public-Key-Pins-Report-Only:
-      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
-      Set-Cookie:
-      - trk=00cccd4a-e55b-42f7-aec4-c5505d7f9ea8; Path=/; Max-Age=31536000; HttpOnly;
-        Secure; SameSite=None
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Bolt-Api-Version:
-      - '2022-01-01'
-      X-Bolt-Trace-Id:
-      - Root=1-6282377c-3e3afdfd4f35e7472e28fa49
-      X-Device-Id:
-      - 8380fe1a24237cc9dc98d4c9c000e04ce94c19bf9301bed7a389b01e6e62d3c5
-      X-Envoy-Upstream-Service-Time:
-      - '54'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
-        Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
-  recorded_at: Mon, 16 May 2022 11:37:32 GMT
-- request:
-    method: get
-    uri: https://api-sandbox.bolt.com/v1/account
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Authorization:
-      - "<BEARER AUTHORIZATION>"
-      X-Api-Key:
-      - "<API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Mon, 16 May 2022 11:37:33 GMT
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '200'
-      Connection:
-      - keep-alive
-      Public-Key-Pins-Report-Only:
-      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
-      Set-Cookie:
-      - trk=9f0458e7-edae-4fa4-ac20-bf8a44f1dfae; Path=/; Max-Age=31536000; HttpOnly;
-        Secure; SameSite=None
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Bolt-Api-Version:
-      - '2022-01-01'
-      X-Bolt-Trace-Id:
-      - Root=1-6282377d-5c4c52465481e9c10a25cfeb
-      X-Device-Id:
-      - e21efc8f82b9628132d556ce7033ae227bcb36a899e46868b297a983fa2fae2a
-      X-Envoy-Upstream-Service-Time:
-      - '54'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '{"profile":{"first_name":"Piyush","last_name":"Swain","email":"piyushswain+bolt@nebulab.com","phone":"+919668487987","name":"Piyush
-        Swain"},"addresses":[],"payment_methods":[],"has_bolt_account":true}'
-  recorded_at: Mon, 16 May 2022 11:37:33 GMT
-recorded_with: VCR 6.0.0
+      string: '{"profile":{"first_name":"asdasd","last_name":"fsfasdf","email":"paulodalberti@nebulab.com","phone":"","name":"asdasd
+        fsfasdf"},"addresses":[],"payment_methods":[{"id":"CAgP9uNSEZBNL","type":"card","last4":"1111","network":"visa","default":true,"exp_month":4,"exp_year":2098}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 00:52:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncPaymentSourcesService/_call/creates_a_new_payment_source_with_card_ID.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncPaymentSourcesService/_call/creates_a_new_payment_source_with_card_ID.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 00:52:42 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '301'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=9f69895b-8b34-4f62-a508-f09650d5c4d2; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-6286e65a-60b62fbb00698d3507bec285
+      X-Device-Id:
+      - b14d37786ac06e9df121d6418689d1ee7f8472e4116cd32892f2e29ad103bc71
+      X-Envoy-Upstream-Service-Time:
+      - '73'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"asdasd","last_name":"fsfasdf","email":"paulodalberti@nebulab.com","phone":"","name":"asdasd
+        fsfasdf"},"addresses":[],"payment_methods":[{"id":"CAgP9uNSEZBNL","type":"card","last4":"1111","network":"visa","default":true,"exp_month":4,"exp_year":2098}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 00:52:44 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/solidus_bolt/payment_source_spec.rb
+++ b/spec/models/solidus_bolt/payment_source_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe SolidusBolt::PaymentSource, type: :model do
       'card_id',
       'create_bolt_account',
       'created_at',
-      'updated_at'
+      'updated_at',
+      'user_id'
     ]
   }
 

--- a/spec/requests/spree/checkout_controller_spec.rb
+++ b/spec/requests/spree/checkout_controller_spec.rb
@@ -3,19 +3,21 @@ require 'spec_helper'
 RSpec.describe "Spree::CheckoutController", type: :request do
   stub_authorization!
 
+  let(:user) { order.user }
+
+  before do
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Spree::CheckoutController).to receive(:current_order).and_return(order)
+    allow_any_instance_of(SolidusBolt::BoltConfiguration).to(
+      receive(:embed_js).and_return('https://connect-sandbox.bolt.com/embed.js')
+    )
+    # rubocop:enable RSpec/AnyInstance
+  end
+
   describe "GET /checkout/address" do
-    let(:user) { order.user }
     let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:address) }
 
-    before do
-      allow(SolidusBolt::Users::SyncAddressesService).to receive(:call)
-      # rubocop:disable RSpec/AnyInstance
-      allow_any_instance_of(Spree::CheckoutController).to receive(:current_order).and_return(order)
-      allow_any_instance_of(SolidusBolt::BoltConfiguration).to(
-        receive(:embed_js).and_return('https://connect-sandbox.bolt.com/embed.js')
-      )
-      # rubocop:enable RSpec/AnyInstance
-    end
+    before { allow(SolidusBolt::Users::SyncAddressesService).to receive(:call) }
 
     it 'returns a successful response' do
       get '/checkout/address'
@@ -27,6 +29,24 @@ RSpec.describe "Spree::CheckoutController", type: :request do
       get '/checkout/address'
 
       expect(SolidusBolt::Users::SyncAddressesService).to have_received(:call)
+    end
+  end
+
+  describe "GET /checkout/payment" do
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:payment) }
+
+    before { allow(SolidusBolt::Users::SyncPaymentSourcesService).to receive(:call) }
+
+    it 'returns a successful response' do
+      get '/checkout/payment'
+
+      expect(response.status).to eq 200
+    end
+
+    it 'calls the service to sync payment sources' do
+      get '/checkout/payment'
+
+      expect(SolidusBolt::Users::SyncPaymentSourcesService).to have_received(:call)
     end
   end
 end

--- a/spec/services/solidus_bolt/accounts/detail_service_spec.rb
+++ b/spec/services/solidus_bolt/accounts/detail_service_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 
 RSpec.describe SolidusBolt::Accounts::DetailService, :vcr, :bolt_configuration do
   describe '#call', vcr: true do
-    subject(:api) { described_class.new(access_token: access_token) }
+    subject(:detail) { described_class.call(access_token: access_token) }
 
     context 'with wrong access_token' do
       let(:access_token) { 'Bolt Access Token' }
 
       it 'gives an error' do
-        expect{ api.call }.to raise_error(SolidusBolt::ServerError, 'This action is forbidden.')
+        expect{ detail }.to raise_error(SolidusBolt::ServerError, 'This action is forbidden.')
       end
     end
 
@@ -18,9 +18,9 @@ RSpec.describe SolidusBolt::Accounts::DetailService, :vcr, :bolt_configuration d
       let(:access_token) { ENV['BOLT_ACCESS_TOKEN'] }
 
       it 'receives a successful response' do
-        expect(api.call).to match hash_including('profile')
-        expect(api.call).to match hash_including('addresses')
-        expect(api.call).to match hash_including('payment_methods')
+        expect(detail).to match hash_including('profile')
+        expect(detail).to match hash_including('addresses')
+        expect(detail).to match hash_including('payment_methods')
       end
     end
   end

--- a/spec/services/solidus_bolt/users/sync_payment_sources_service_spec.rb
+++ b/spec/services/solidus_bolt/users/sync_payment_sources_service_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::Users::SyncPaymentSourcesService, :vcr, :bolt_configuration do
+  subject(:sync_payment_sources) do
+    described_class.call(user: user, access_token: ENV.fetch('BOLT_ACCESS_TOKEN', 'Fake_access_token'))
+  end
+
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    it 'creates a new payment source with card ID' do
+      expect { sync_payment_sources }.to change { SolidusBolt::PaymentSource.count }.by(1)
+      bolt_payment_source = SolidusBolt::PaymentSource.last
+      expect(bolt_payment_source.card_id).to be_present
+      expect(bolt_payment_source.card_last4).to be_present
+      expect(bolt_payment_source.card_expiration).to be_present
+      expect(bolt_payment_source.user_id).to eq(user.id)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/nebulab/solidus_bolt/issues/78

The purpose of this PR is create a new relation between Bolt PaymentSource and Spree::User and sync the local data with that on Bolt. For that end in the checkout flow we'll make an API call to get the current user's details and update the payment sources before displaying the payment options.

- adds 1-N relation between User and PaymentSource
- creates service to sync PaymentSource from Bolt
- incorporates the service in the checkout flow
- refactors one spec