### PR TITLE
Sync Bolt Addresses with Solidus User

### DIFF
--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_addresses.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_addresses.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module SpreeCheckoutController
+    module RefreshBoltAddresses
+      def before_address
+        SolidusBolt::Users::SyncAddressesService.call(
+          user: spree_current_user, access_token: session[:bolt_access_token]
+        )
+
+        super
+      end
+
+      Spree::CheckoutController.prepend self
+    end
+  end
+end

--- a/app/services/solidus_bolt/users/sync_addresses_service.rb
+++ b/app/services/solidus_bolt/users/sync_addresses_service.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module Users
+    class SyncAddressesService < SolidusBolt::BaseService
+      attr_reader :user, :access_token
+
+      def initialize(user:, access_token:)
+        @access_token = access_token
+        @user = user
+        super
+      end
+
+      def call
+        return if user.nil? || access_token.nil?
+
+        bolt_addresses.each do |bolt_address|
+          default = bolt_address['default']
+          address = convert_to_solidus(bolt_address)
+          address[:phone] = user_info['profile']['phone']
+          user.save_in_address_book(address, default, :shipping)
+          user.save_in_address_book(address, default, :billing)
+        end
+      end
+
+      private
+
+      def user_info
+        @user_info ||= Accounts::DetailService.call(access_token: access_token)
+      end
+
+      def bolt_addresses
+        user_info['addresses']
+      end
+
+      def convert_to_solidus(bolt_address)
+        country = Spree::Country.find_by(iso: bolt_address['country_code'])
+        {
+          address1: bolt_address['street_address1'],
+          city: bolt_address['locality'],
+          state: country.states.find_by(abbr: bolt_address['region_code']),
+          zipcode: bolt_address['postal_code'],
+          name: bolt_address['name'],
+          country: country,
+          phone: user_info['profile']
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_bill_address_to_the_user.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_bill_address_to_the_user.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 11:28:44 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '568'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=ff3064f5-423d-4ccb-8c69-c99d68d3b23f; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62877b6c-2c72312277f16ad84b61bcff
+      X-Device-Id:
+      - cf7850bbef6674a2a25c543def5ef025b040b2a183a73bf92ff61424a6a18c8e
+      X-Envoy-Upstream-Service-Time:
+      - '18'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
+        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
+        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 11:28:44 GMT
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 11:28:44 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '568'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=e9407ca6-d196-4a0f-b231-8d7f18b7aab8; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62877b6c-5457e743775ef6cd191e8eeb
+      X-Device-Id:
+      - 155c7a2627b119007862ae20807dc7fe544d7fef9eb7fca605d7f3ba700cad01
+      X-Envoy-Upstream-Service-Time:
+      - '17'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
+        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
+        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 11:28:44 GMT
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 11:28:45 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '568'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=8f88d13b-09f2-4c74-b24f-f9389bd84f26; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62877b6d-7867be48633b5ba967d700ce
+      X-Device-Id:
+      - 0a632543de2188e14fb97a37efcb5f6a031ac2e48bbda2ea88630b85368f2a43
+      X-Envoy-Upstream-Service-Time:
+      - '18'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
+        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
+        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 11:28:45 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_ship_address_to_the_user.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_ship_address_to_the_user.yml
@@ -1,0 +1,165 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 11:28:41 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '568'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=cf6cb9b6-d933-4f78-8e5d-f2d19950f19a; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62877b69-482e58ce1eedfd33280bc676
+      X-Device-Id:
+      - 232d6cca3392e0cae61de13548ef4414540876c1554215312b6303539da28439
+      X-Envoy-Upstream-Service-Time:
+      - '20'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
+        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
+        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 11:28:41 GMT
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 11:28:42 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '568'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=86009b52-071c-4a79-86fe-5e4bfc1b409f; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62877b6a-05e806ee316c5e56744992b0
+      X-Device-Id:
+      - 153b3dee1dbffff3eaae03a6d0f112b66dc4fd00ab84744e1f5c7d6d5cfd9638
+      X-Envoy-Upstream-Service-Time:
+      - '18'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
+        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
+        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 11:28:42 GMT
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 20 May 2022 11:28:43 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '568'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=55c667e7-7b06-43c8-a906-833e8f45dfd3; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62877b6b-6bc426ab5c474b924918d47f
+      X-Device-Id:
+      - bd3005f3649758fc88a8be35bac4386cd0496fa234aa1850ccc4886a88636192
+      X-Envoy-Upstream-Service-Time:
+      - '74'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
+        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
+        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+  recorded_at: Fri, 20 May 2022 11:28:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/requests/spree/checkout_controller_spec.rb
+++ b/spec/requests/spree/checkout_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe "Spree::CheckoutController", type: :request do
+  stub_authorization!
+
+  describe "GET /checkout/address" do
+    let(:user) { order.user }
+    let(:order) { Spree::TestingSupport::OrderWalkthrough.up_to(:address) }
+
+    before do
+      allow(SolidusBolt::Users::SyncAddressesService).to receive(:call)
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Spree::CheckoutController).to receive(:current_order).and_return(order)
+      allow_any_instance_of(SolidusBolt::BoltConfiguration).to(
+        receive(:embed_js).and_return('https://connect-sandbox.bolt.com/embed.js')
+      )
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    it 'returns a successful response' do
+      get '/checkout/address'
+
+      expect(response.status).to eq 200
+    end
+
+    it 'calls the service to sync addresses' do
+      get '/checkout/address'
+
+      expect(SolidusBolt::Users::SyncAddressesService).to have_received(:call)
+    end
+  end
+end

--- a/spec/services/solidus_bolt/users/sync_addresses_service_spec.rb
+++ b/spec/services/solidus_bolt/users/sync_addresses_service_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::Users::SyncAddressesService, :vcr, :bolt_configuration do
+  subject(:sync_addresses_service) do
+    described_class.call(user: user, access_token: ENV.fetch('BOLT_ACCESS_TOKEN', 'Fake_access_token'))
+  end
+
+  let(:user) { create(:user) }
+  let(:country) { state.country }
+  let(:state) { create(:state) }
+
+  before do
+    allow(Spree::Country).to receive(:find_by).and_return(country)
+    allow(Spree::State).to receive(:find_by).and_return(state)
+    allow(country).to receive(:states).and_return(Spree::State)
+  end
+
+  describe '#call', vcr: true do
+    it 'adds the ship_address to the user' do
+      expect { sync_addresses_service }.to change(user, :ship_address).from(nil)
+    end
+
+    it 'adds the bill_address to the user' do
+      expect { sync_addresses_service }.to change(user, :bill_address).from(nil)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,8 @@ require 'solidus_dev_support/rspec/feature_helper'
 # in spec/support/ and its subdirectories.
 Dir["#{__dir__}/support/**/*.rb"].sort.each { |f| require f }
 
+require 'spree/testing_support/order_walkthrough'
+
 # Requires factories defined in lib/solidus_bolt/testing_support/factories.rb
 SolidusDevSupport::TestingSupport::Factories.load_for(SolidusBolt::Engine)
 


### PR DESCRIPTION
This PR adds the ability to sync bolt addresses from the Bolt account to the solidus user anytime the user visits the `checkout/address` page.