### PR TITLE
add address to bolt

### DIFF
--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module SpreeCheckoutController
+    module AddAddressesToBolt
+      def finalize_order
+        spree_current_user&.addresses&.each do |address|
+          SolidusBolt::Accounts::AddAddressService.call(
+            order: current_order, access_token: session[:bolt_access_token], address: address
+          )
+        end
+
+        super
+      end
+
+      Spree::CheckoutController.prepend self
+    end
+  end
+end

--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
@@ -4,10 +4,12 @@ module SolidusBolt
   module SpreeCheckoutController
     module AddAddressesToBolt
       def finalize_order
-        spree_current_user&.addresses&.each do |address|
-          SolidusBolt::Accounts::AddAddressService.call(
-            order: current_order, access_token: session[:bolt_access_token], address: address
-          )
+        if session[:bolt_access_token] && current_order.payments.last&.source_type == "SolidusBolt::PaymentSource"
+          spree_current_user.addresses.each do |address|
+            SolidusBolt::Accounts::AddAddressService.call(
+              order: current_order, access_token: session[:bolt_access_token], address: address
+            )
+          end
         end
 
         super

--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
@@ -6,7 +6,7 @@ module SolidusBolt
       def finalize_order
         if session[:bolt_access_token] && current_order.payments.last&.source_type == "SolidusBolt::PaymentSource"
           spree_current_user.addresses.each do |address|
-            SolidusBolt::Accounts::AddAddressService.call(
+            SolidusBolt::AddAddressJob.perform_later(
               order: current_order, access_token: session[:bolt_access_token], address: address
             )
           end

--- a/app/jobs/solidus_bolt/add_address_job.rb
+++ b/app/jobs/solidus_bolt/add_address_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  class AddAddressJob < ApplicationJob
+    def perform(order:, access_token:, address:)
+      SolidusBolt::Accounts::AddAddressService.call(
+        order: order, access_token: access_token, address: address
+      )
+    end
+  end
+end

--- a/app/services/solidus_bolt/accounts/add_address_service.rb
+++ b/app/services/solidus_bolt/accounts/add_address_service.rb
@@ -13,10 +13,25 @@ module SolidusBolt
       end
 
       def call
+        return if address_already_uploaded?
+
         add_address
       end
 
       private
+
+      def bolt_addresses
+        @bolt_addresses ||= SolidusBolt::Accounts::DetailService.call(access_token: access_token)['addresses']
+      end
+
+      def address_already_uploaded?
+        bolt_addresses.any? do |bolt_address|
+          bolt_address['street_address1'] == address.address1 &&
+          bolt_address['locality'] == address.city &&
+          bolt_address['region'] == address.state&.abbr &&
+          bolt_address['postal_code'] == address.zipcode
+        end
+      end
 
       def add_address
         handle_result(HTTParty.post("#{api_base_url}/#{api_version}/account/addresses", build_options))

--- a/app/services/solidus_bolt/accounts/add_address_service.rb
+++ b/app/services/solidus_bolt/accounts/add_address_service.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module Accounts
+    class AddAddressService < SolidusBolt::BaseService
+      attr_reader :order, :address, :access_token
+
+      def initialize(order:, address:, access_token:)
+        @order = order
+        @address = address
+        @access_token = access_token
+        super
+      end
+
+      def call
+        add_address
+      end
+
+      private
+
+      def add_address
+        handle_result(HTTParty.post("#{api_base_url}/#{api_version}/account/addresses", build_options))
+      end
+
+      def address_body
+        country = address.country
+        {
+          street_address1: address.address1,
+          street_address2: address.address2,
+          locality: address.city,
+          region: address.state&.abbr,
+          postal_code: address.zipcode,
+          country_code: country.iso,
+          first_name: Spree::Address::Name.new(address.name).first_name,
+          last_name: Spree::Address::Name.new(address.name).last_name,
+          phone: address.phone,
+          email: order.email
+        }.to_json
+      end
+
+      def build_options
+        {
+          body: address_body,
+          headers: {
+            'Authorization' => "Bearer #{access_token}",
+            'Content-Type' => 'application/json'
+          }.merge(authentication_header)
+        }
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_correct_access_token/receives_a_successful_response.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_correct_access_token/receives_a_successful_response.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-sandbox.bolt.com/v1/account/addresses
+    body:
+      encoding: UTF-8
+      string: '{"street_address1":"PO Box 1337","street_address2":"Northwest","locality":"Herndon","region":"AL","postal_code":"10003","country_code":"US","first_name":"John","last_name":"Von
+        Doe","phone":"555-555-0199","email":"email2@example.com"}'
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 27 May 2022 02:26:28 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '327'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=b007682d-f2ce-4b2b-986a-2f4b8acc8bac; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-629036d4-08cf1433169e778b1346d649
+      X-Device-Id:
+      - cc9daaa116250ddb4e346e2c192d494d708406a0870ffe62aa9a489709feac62
+      X-Envoy-Upstream-Service-Time:
+      - '65'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"id":"SA728NNovMq9H","street_address1":"PO Box 1337","street_address2":"Northwest","locality":"Herndon","region":"AL","region_code":"AL","postal_code":"10003","country_code":"US","name":"John
+        Von Doe","first_name":"John","last_name":"Von Doe","phone_number":"555-555-0199","email_address":"email2@example.com","default":false}'
+  recorded_at: Fri, 27 May 2022 02:26:30 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_existing_address/skips_the_add_address_call.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_existing_address/skips_the_add_address_call.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 31 May 2022 01:24:31 GMT
+      - Tue, 31 May 2022 01:23:36 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Transfer-Encoding:
@@ -33,18 +33,18 @@ http_interactions:
       Public-Key-Pins-Report-Only:
       - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
       Set-Cookie:
-      - trk=6ed2577d-8b6e-40d7-b914-5f99f4232557; Path=/; Max-Age=31536000; HttpOnly;
+      - trk=0049c155-2eb5-44fd-9a20-c73a847baa68; Path=/; Max-Age=31536000; HttpOnly;
         Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Bolt-Api-Version:
       - '2022-01-01'
       X-Bolt-Trace-Id:
-      - Root=1-62956e4f-1a1d5d9371616b3e0bd6cead
+      - Root=1-62956e18-5aef499c7a23d91d0b98ba02
       X-Device-Id:
-      - a86166e54134f40be90bf98bdf9f1fcac49d23ac4259202b5038010473c636ba
+      - ade588f38215c8bd482908a0a3d00e03cfd2c3207c04ea86f1d04a9a83be77a8
       X-Envoy-Upstream-Service-Time:
-      - '36'
+      - '141'
       Server:
       - envoy
     body:
@@ -78,60 +78,5 @@ http_interactions:
         Von Doe","first_name":"John","last_name":"Von Doe","phone_number":"555-555-0199","email_address":"example@email.com"},"network":"visa","default":false,"exp_month":5,"exp_year":2023},{"id":"CAeZyt3phevU4","type":"card","last4":"1004","billing_address":{"id":"AAaGXye8QrAc1","street_address1":"10
         Lovely Street","street_address2":"Northwest","locality":"Herndon","region":"AL","region_code":"AL","postal_code":"10001","country_code":"US","name":"John
         Von Doe","first_name":"John","last_name":"Von Doe","phone_number":"555-555-0199","email_address":"example@email.com"},"network":"visa","default":false,"exp_month":5,"exp_year":2023},{"id":"CAgP9uNSEZBNL","type":"card","last4":"1111","network":"visa","default":false,"exp_month":4,"exp_year":2098}],"has_bolt_account":true}'
-  recorded_at: Tue, 31 May 2022 01:24:31 GMT
-- request:
-    method: post
-    uri: https://api-sandbox.bolt.com/v1/account/addresses
-    body:
-      encoding: UTF-8
-      string: '{"street_address1":"6420","street_address2":"Northwest","locality":"Herndon","region":"AL","postal_code":"10005","country_code":"US","first_name":"John","last_name":"Von
-        Doe","phone":"555-555-0199","email":"email2@example.com"}'
-    headers:
-      Authorization:
-      - "<BEARER AUTHORIZATION>"
-      Content-Type:
-      - application/json
-      X-Api-Key:
-      - "<API_KEY>"
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Tue, 31 May 2022 01:24:32 GMT
-      Content-Type:
-      - application/json; charset=UTF-8
-      Content-Length:
-      - '320'
-      Connection:
-      - keep-alive
-      Public-Key-Pins-Report-Only:
-      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
-      Set-Cookie:
-      - trk=26fa7207-763a-4620-a372-ac05b017834f; Path=/; Max-Age=31536000; HttpOnly;
-        Secure; SameSite=None
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      X-Bolt-Api-Version:
-      - '2022-01-01'
-      X-Bolt-Trace-Id:
-      - Root=1-62956e50-70f9b1fb090f35a065a34527
-      X-Device-Id:
-      - fa03959d09d885b5e85ab84c0070c6ce61dedeadc49829e6aef673d767a766df
-      X-Envoy-Upstream-Service-Time:
-      - '64'
-      Server:
-      - envoy
-    body:
-      encoding: UTF-8
-      string: '{"id":"SAfjEyWzmuxRs","street_address1":"6420","street_address2":"Northwest","locality":"Herndon","region":"AL","region_code":"AL","postal_code":"10005","country_code":"US","name":"John
-        Von Doe","first_name":"John","last_name":"Von Doe","phone_number":"555-555-0199","email_address":"email2@example.com","default":false}'
-  recorded_at: Tue, 31 May 2022 01:24:32 GMT
+  recorded_at: Tue, 31 May 2022 01:23:36 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_wrong_access_token/gives_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_wrong_access_token/gives_an_error.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-sandbox.bolt.com/v1/account/addresses
+    body:
+      encoding: UTF-8
+      string: '{"street_address1":"PO Box 1337","street_address2":"Northwest","locality":"Herndon","region":"AL","postal_code":"10001","country_code":"US","first_name":"John","last_name":"Von
+        Doe","phone":"555-555-0199","email":"email1@example.com"}'
+    headers:
+      Authorization:
+      - "<BEARER AUTHORIZATION>"
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 403
+      message: Forbidden
+    headers:
+      Date:
+      - Fri, 27 May 2022 02:26:28 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '89'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=a1d30bba-3833-4268-b835-213d78a90eb8; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-629036d3-4ca1fe12482f64583f803938
+      X-Device-Id:
+      - 37839ef8af1c9f83bc577c6f377aa9e576a512065a8cae738f8efdac5002ae1f
+      X-Envoy-Upstream-Service-Time:
+      - '52'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"result":{"success":false},"errors":[{"code":18,"message":"This action
+        is forbidden."}]}'
+  recorded_at: Fri, 27 May 2022 02:26:30 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_wrong_access_token/gives_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Accounts_AddAddressService/_call/with_wrong_access_token/gives_an_error.yml
@@ -1,17 +1,14 @@
 ---
 http_interactions:
 - request:
-    method: post
-    uri: https://api-sandbox.bolt.com/v1/account/addresses
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/account
     body:
-      encoding: UTF-8
-      string: '{"street_address1":"PO Box 1337","street_address2":"Northwest","locality":"Herndon","region":"AL","postal_code":"10001","country_code":"US","first_name":"John","last_name":"Von
-        Doe","phone":"555-555-0199","email":"email1@example.com"}'
+      encoding: US-ASCII
+      string: ''
     headers:
       Authorization:
       - "<BEARER AUTHORIZATION>"
-      Content-Type:
-      - application/json
       X-Api-Key:
       - "<API_KEY>"
       Accept-Encoding:
@@ -26,7 +23,7 @@ http_interactions:
       message: Forbidden
     headers:
       Date:
-      - Fri, 27 May 2022 02:26:28 GMT
+      - Tue, 31 May 2022 01:20:12 GMT
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
@@ -36,23 +33,23 @@ http_interactions:
       Public-Key-Pins-Report-Only:
       - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
       Set-Cookie:
-      - trk=a1d30bba-3833-4268-b835-213d78a90eb8; Path=/; Max-Age=31536000; HttpOnly;
+      - trk=1a93c681-6c5d-4637-b241-f89d4aee20d6; Path=/; Max-Age=31536000; HttpOnly;
         Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       X-Bolt-Api-Version:
       - '2022-01-01'
       X-Bolt-Trace-Id:
-      - Root=1-629036d3-4ca1fe12482f64583f803938
+      - Root=1-62956d4c-70b90ea629e9228431b92000
       X-Device-Id:
-      - 37839ef8af1c9f83bc577c6f377aa9e576a512065a8cae738f8efdac5002ae1f
+      - 9e1083e0992b47d0076132182970216f7f1cca11ab0c8cbbd21b6273287199c7
       X-Envoy-Upstream-Service-Time:
-      - '52'
+      - '32'
       Server:
       - envoy
     body:
       encoding: UTF-8
       string: '{"result":{"success":false},"errors":[{"code":18,"message":"This action
         is forbidden."}]}'
-  recorded_at: Fri, 27 May 2022 02:26:30 GMT
+  recorded_at: Tue, 31 May 2022 01:20:12 GMT
 recorded_with: VCR 6.1.0

--- a/spec/jobs/solidus_bolt/add_address_job_spec.rb
+++ b/spec/jobs/solidus_bolt/add_address_job_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::AddAddressJob do
+  subject(:add_address_job) { described_class.perform_now(order: order, access_token: access_token, address: address) }
+
+  let(:order) { build(:order) }
+  let(:address) { build(:address) }
+  let(:access_token) { 'accesstoken' }
+
+  before { allow(SolidusBolt::Accounts::AddAddressService).to receive(:call) }
+
+  it 'calls the AddAddressService' do
+    add_address_job
+    expect(SolidusBolt::Accounts::AddAddressService).to have_received(:call).with(
+      order: order, access_token: access_token, address: address
+    )
+  end
+end

--- a/spec/requests/spree/checkout_controller_spec.rb
+++ b/spec/requests/spree/checkout_controller_spec.rb
@@ -3,11 +3,12 @@ require 'spec_helper'
 RSpec.describe "Spree::CheckoutController", type: :request do
   stub_authorization!
 
-  let(:user) { order.user }
+  let(:user) { create(:user_with_addresses) }
 
   before do
     # rubocop:disable RSpec/AnyInstance
     allow_any_instance_of(Spree::CheckoutController).to receive(:current_order).and_return(order)
+    allow_any_instance_of(Spree::CheckoutController).to receive(:spree_current_user).and_return(user)
     allow_any_instance_of(SolidusBolt::BoltConfiguration).to(
       receive(:embed_js).and_return('https://connect-sandbox.bolt.com/embed.js')
     )
@@ -47,6 +48,32 @@ RSpec.describe "Spree::CheckoutController", type: :request do
       get '/checkout/payment'
 
       expect(SolidusBolt::Users::SyncPaymentSourcesService).to have_received(:call)
+    end
+  end
+
+  describe 'PATCH /checkout/update/confirm' do
+    let(:order) { FactoryBot.create(:order_with_totals) }
+
+    before do
+      # use test preparation from solidusio/solidus/frontend/spec/controllers/spree/checkout_controller_spec.rb
+      # because Spree::TestingSupport::OrderWalkthrough.up_to(:confirm) doesn't work
+      order.update! user: user
+      order.update(state: 'confirm')
+      create(:payment, amount: order.total, order: order)
+      order.create_proposed_shipments
+      order.payments.reload
+
+      allow(SolidusBolt::Accounts::AddAddressService).to receive(:call)
+
+      patch '/checkout/update/confirm'
+    end
+
+    it 'redirects to completion route' do
+      expect(response).to redirect_to spree.order_path(order)
+    end
+
+    it 'calls the service to add addresses' do
+      expect(SolidusBolt::Accounts::AddAddressService).to have_received(:call).twice
     end
   end
 end

--- a/spec/services/solidus_bolt/accounts/add_address_service_spec.rb
+++ b/spec/services/solidus_bolt/accounts/add_address_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::Accounts::AddAddressService, :vcr, :bolt_configuration do
+  describe '#call', vcr: true do
+    subject(:add_address) { described_class.call(access_token: access_token, order: order, address: address) }
+
+    let(:order) { build(:order) }
+    let(:address) { order.bill_address }
+
+    context 'with wrong access_token' do
+      let(:access_token) { 'Bolt Access Token' }
+
+      it 'gives an error' do
+        expect{ add_address }.to raise_error(SolidusBolt::ServerError, 'This action is forbidden.')
+      end
+    end
+
+    context 'with correct access_token' do
+      let(:access_token) { ENV['BOLT_ACCESS_TOKEN'] }
+
+      it 'receives a successful response' do
+        expect(add_address).to match hash_including('id')
+        expect(add_address['street_address1']).to eq(address.address1)
+      end
+    end
+  end
+end
+
+# This spec depends on the bolt_access_token that needs to be generated manually
+# and added to the environment variable BOLT_ACCESS_TOKEN.
+# Generate a new access token by logging into an existing user bolt account on
+# development environment and copying the token from the session['bolt_access_token'] key.

--- a/spec/services/solidus_bolt/accounts/add_address_service_spec.rb
+++ b/spec/services/solidus_bolt/accounts/add_address_service_spec.rb
@@ -19,10 +19,21 @@ RSpec.describe SolidusBolt::Accounts::AddAddressService, :vcr, :bolt_configurati
 
     context 'with correct access_token' do
       let(:access_token) { ENV['BOLT_ACCESS_TOKEN'] }
+      let(:address) { build(:address, address1: '6420') }
 
       it 'receives a successful response' do
         expect(add_address).to match hash_including('id')
         expect(add_address['street_address1']).to eq(address.address1)
+      end
+    end
+
+    context 'with existing address' do
+      let(:access_token) { ENV['BOLT_ACCESS_TOKEN'] }
+
+      let(:address) { build(:address, address1: 'PO Box 1337', zipcode: '10001') }
+
+      it 'skips the add_address call' do
+        expect(add_address).to be(nil)
       end
     end
   end


### PR DESCRIPTION
This PR automatically sends signed in Bolt user's address from the /checkout/address step to Bolt, in order to keep the addresses up to date. Since we need the user's bolt_access_token for it, the call is being done from a checkout's controller callback instead of the Adress' Model callback.

About manual testing: I wasn't able to see the address being created in my personal Bolt account, but when calling the DetailsService after going through the checkout flow, the address did appear in the payload.