### PR TITLE
Refresh access_token Service

### DIFF
--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/add_addresses_to_bolt.rb
@@ -7,7 +7,9 @@ module SolidusBolt
         if session[:bolt_access_token] && current_order.payments.last&.source_type == "SolidusBolt::PaymentSource"
           spree_current_user.addresses.each do |address|
             SolidusBolt::AddAddressJob.perform_later(
-              order: current_order, access_token: session[:bolt_access_token], address: address
+              order: current_order,
+              access_token: SolidusBolt::Users::RefreshAccessTokenService.call(session: session),
+              address: address
             )
           end
         end

--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_addresses.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_addresses.rb
@@ -5,7 +5,7 @@ module SolidusBolt
     module RefreshBoltAddresses
       def before_address
         SolidusBolt::Users::SyncAddressesService.call(
-          user: spree_current_user, access_token: session[:bolt_access_token]
+          user: spree_current_user, access_token: SolidusBolt::Users::RefreshAccessTokenService.call(session: session)
         )
 
         super

--- a/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_payment_source.rb
+++ b/app/decorators/controllers/solidus_bolt/spree_checkout_controller/refresh_bolt_payment_source.rb
@@ -5,7 +5,7 @@ module SolidusBolt
     module RefreshBoltPaymentSource
       def before_payment
         SolidusBolt::Users::SyncPaymentSourcesService.call(
-          user: spree_current_user, access_token: session[:bolt_access_token]
+          user: spree_current_user, access_token: SolidusBolt::Users::RefreshAccessTokenService.call(session: session)
         )
 
         super

--- a/app/decorators/omniauth/strategies/bolt_decorator.rb
+++ b/app/decorators/omniauth/strategies/bolt_decorator.rb
@@ -3,7 +3,12 @@
 module SolidusBolt
   module OmniAuth::Strategies::BoltDecorator # rubocop:disable Style/ClassAndModuleChildren
     def callback_phase
-      super.tap { session[:bolt_access_token] = @access_token }
+      super.tap do
+        session[:bolt_access_token] = @access_token
+        session[:bolt_expiration_time] = @expiration_time
+        session[:bolt_refresh_token] = @refresh_token
+        session[:bolt_refresh_token_scope] = @refresh_token_scope
+      end
     end
 
     ::OmniAuth::Strategies::Bolt.prepend self

--- a/app/services/solidus_bolt/users/refresh_access_token_service.rb
+++ b/app/services/solidus_bolt/users/refresh_access_token_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module Users
+    class RefreshAccessTokenService < SolidusBolt::BaseService
+      attr_reader :session
+
+      def initialize(session:)
+        @session = session
+        super
+      end
+
+      def call
+        return if session[:bolt_access_token].nil?
+        return session[:bolt_access_token] if session[:bolt_expiration_time] >= Time.now.utc
+
+        refresh_access_token
+      end
+
+      private
+
+      def refresh_access_token
+        response = handle_result(HTTParty.post("#{api_base_url}/#{api_version}/oauth/token", build_options))
+
+        session[:bolt_expiration_time] = Time.now.utc + response['expires_in']
+        session[:bolt_refresh_token] = response['refresh_token']
+        session[:bolt_refresh_token_scope] = response['refresh_token_scope']
+        session[:bolt_access_token] = response['access_token']
+      end
+
+      def build_options
+        {
+          body: {
+            grant_type: 'refresh_token',
+            refresh_token: session[:bolt_refresh_token],
+            client_id: publishable_key,
+            scope: session[:bolt_refresh_token_scope],
+            client_secret: api_key
+          }
+        }
+      end
+    end
+  end
+end

--- a/spec/requests/spree/checkout_controller_spec.rb
+++ b/spec/requests/spree/checkout_controller_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe "Spree::CheckoutController", type: :request do
       let(:access_token) { 'accesstoken' }
       let(:payment) { create(:bolt_payment, amount: order.total, order: order) }
 
+      before { allow(SolidusBolt::Users::RefreshAccessTokenService).to receive(:call).and_return(access_token) }
+
       it 'calls the job to add addresses' do
         expect { confirm_order }.to(have_enqueued_job(SolidusBolt::AddAddressJob).twice.with { |hash|
           expect(hash[:order]).to eq(order)

--- a/spec/services/solidus_bolt/users/refresh_access_token_service_spec.rb
+++ b/spec/services/solidus_bolt/users/refresh_access_token_service_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::Users::RefreshAccessTokenService do
+  subject(:refresh_access_token) { described_class.call(session: session) }
+
+  let(:session) { { bolt_access_token: bolt_access_token, bolt_expiration_time: bolt_expiration_time } }
+
+  describe '#call' do
+    context 'when not bolt user' do
+      let(:bolt_access_token) { nil }
+      let(:bolt_expiration_time) { nil }
+
+      it 'returns nil' do
+        expect(refresh_access_token).to be_nil
+      end
+    end
+
+    context 'with valid token' do
+      let(:bolt_access_token) { 'accesstoken' }
+      let(:bolt_expiration_time) { Time.now.utc + 10.minutes }
+
+      it 'returns current access token' do
+        expect(refresh_access_token).to eq(bolt_access_token)
+      end
+    end
+
+    context 'with expired token' do
+      let(:bolt_access_token) { 'accesstoken' }
+      let(:bolt_expiration_time) { Time.now.utc - 10.minutes }
+      let(:result) { { 'access_token' => 'newaccesstoken', 'expires_in' => 3600 } }
+
+      before do
+        allow(HTTParty).to receive(:post).and_return(result)
+        allow(result).to receive(:success?).and_return(true)
+        allow(result).to receive(:parsed_response).and_return(result)
+      end
+
+      it 'refreshes the access token' do
+        expect(refresh_access_token).to eq('newaccesstoken')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Bolt's access_token expires after a while making some of the API calls we send to Bolt unable to process. With this PR we introduce a service that will refresh the access_token after expiry and rework the code to call said service instead of using `session[:bolt_access_token]`.

Fixes https://github.com/nebulab/solidus_bolt/issues/101
Requires https://github.com/nebulab/omniauth-bolt/pull/2