### PR TITLE
Use address' phone when syncing addresses

### DIFF
--- a/app/services/solidus_bolt/users/sync_addresses_service.rb
+++ b/app/services/solidus_bolt/users/sync_addresses_service.rb
@@ -17,7 +17,6 @@ module SolidusBolt
         bolt_addresses.each do |bolt_address|
           default = bolt_address['default']
           address = convert_to_solidus(bolt_address)
-          address[:phone] = user_info['profile']['phone']
           user.save_in_address_book(address, default, :shipping)
           user.save_in_address_book(address, default, :billing)
         end
@@ -42,7 +41,7 @@ module SolidusBolt
           zipcode: bolt_address['postal_code'],
           name: bolt_address['name'],
           country: country,
-          phone: user_info['profile']
+          phone: bolt_address['phone_number'] || user_info['profile']['phone']
         }
       end
     end

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_bill_address_to_the_user.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_bill_address_to_the_user.yml
@@ -49,10 +49,10 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
-        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
-        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
-        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+      string: '{"profile":{"first_name":"Danny","last_name":"Dove","email":"dannydove+bolt3@gmail.com","phone":"987654321","name":"Danny
+        Dove"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Danny
+        Dove","first_name":"Danny","last_name":"Dove","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
   recorded_at: Fri, 20 May 2022 11:28:44 GMT
 - request:
     method: get
@@ -103,10 +103,10 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
-        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
-        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
-        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+      string: '{"profile":{"first_name":"Danny","last_name":"Dove","email":"dannydove+bolt3@gmail.com","phone":"987654321","name":"Danny
+        Dove"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Danny
+        Dove","first_name":"Danny","last_name":"Dove","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
   recorded_at: Fri, 20 May 2022 11:28:44 GMT
 - request:
     method: get
@@ -157,9 +157,9 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
-        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
-        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
-        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+      string: '{"profile":{"first_name":"Danny","last_name":"Dove","email":"dannydove+bolt3@gmail.com","phone":"987654321","name":"Danny
+        Dove"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Danny
+        Dove","first_name":"Danny","last_name":"Dove","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
   recorded_at: Fri, 20 May 2022 11:28:45 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_ship_address_to_the_user.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_Users_SyncAddressesService/_call/adds_the_ship_address_to_the_user.yml
@@ -49,10 +49,10 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
-        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
-        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
-        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+      string: '{"profile":{"first_name":"Danny","last_name":"dove","email":"dannydove+bolt3@gmail.com","phone":"987654321","name":"Danny
+        dove"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Danny
+        dove","first_name":"Danny","last_name":"dove","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
   recorded_at: Fri, 20 May 2022 11:28:41 GMT
 - request:
     method: get
@@ -103,10 +103,10 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
-        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
-        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
-        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+      string: '{"profile":{"first_name":"Danny","last_name":"dove","email":"dannydove+bolt3@gmail.com","phone":"987654321","name":"Danny
+        dove"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Danny
+        dove","first_name":"Danny","last_name":"dove","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
   recorded_at: Fri, 20 May 2022 11:28:42 GMT
 - request:
     method: get
@@ -157,9 +157,9 @@ http_interactions:
       - envoy
     body:
       encoding: UTF-8
-      string: '{"profile":{"first_name":"Daniele","last_name":"Palombo","email":"danielepalombo+bolt3@nebulab.com","phone":"+393337290394","name":"Daniele
-        Palombo"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
-        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Daniele
-        Palombo","first_name":"Daniele","last_name":"Palombo","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
+      string: '{"profile":{"first_name":"Danny","last_name":"dove","email":"dannydove+bolt3@gmail.com","phone":"987654321","name":"Danny
+        dove"},"addresses":[{"id":"SA98t82gH2Grd","street_address1":"380 DEGRAW
+        ST","locality":"Brooklyn","region":"NEW YORK","region_code":"NY","postal_code":"11231","country_code":"US","name":"Danny
+        dove","first_name":"Danny","last_name":"dove","default":true}],"payment_methods":[{"id":"CA3tqG8Xg2RwS","type":"card","last4":"1111","network":"visa","default":true,"exp_month":11,"exp_year":2022}],"has_bolt_account":true}'
   recorded_at: Fri, 20 May 2022 11:28:43 GMT
 recorded_with: VCR 6.1.0

--- a/spec/services/solidus_bolt/users/sync_addresses_service_spec.rb
+++ b/spec/services/solidus_bolt/users/sync_addresses_service_spec.rb
@@ -10,6 +10,25 @@ RSpec.describe SolidusBolt::Users::SyncAddressesService, :vcr, :bolt_configurati
   let(:user) { create(:user) }
   let(:country) { state.country }
   let(:state) { create(:state) }
+  let(:payload) do
+    {
+      'profile' => { 'phone' => '987654321' },
+      'addresses' => [{
+        'id' => 'SA98t82gH2Grd',
+        'street_address1' => '380 DEGRAW ST',
+        'locality' => 'Brooklyn',
+        'region' => 'NEW YORK',
+        'region_code' => 'NY',
+        'postal_code' => '11231',
+        'country_code' => 'US',
+        'name' => 'Danny Dove',
+        'first_name' => 'Danny',
+        'last_name' => 'Dove',
+        'default' => true,
+        'phone_number' => phone
+      }]
+    }
+  end
 
   before do
     allow(Spree::Country).to receive(:find_by).and_return(country)
@@ -24,6 +43,32 @@ RSpec.describe SolidusBolt::Users::SyncAddressesService, :vcr, :bolt_configurati
 
     it 'adds the bill_address to the user' do
       expect { sync_addresses_service }.to change(user, :bill_address).from(nil)
+    end
+
+    context 'with address phone number', vcr: false do
+      let(:phone) { '123456789' }
+
+      before do
+        allow(SolidusBolt::Accounts::DetailService).to receive(:call).and_return(payload)
+        sync_addresses_service
+      end
+
+      it 'creates an address with the address phone' do
+        expect(user.bill_address.phone).to eq(phone)
+      end
+    end
+
+    context 'without address phone number', vcr: false do
+      let(:phone) { nil }
+
+      before do
+        allow(SolidusBolt::Accounts::DetailService).to receive(:call).and_return(payload)
+        sync_addresses_service
+      end
+
+      it 'creates an address with the user phone' do
+        expect(user.bill_address.phone).to eq('987654321')
+      end
     end
   end
 end


### PR DESCRIPTION
If an existing Bolt address already has a phone, we should use that one
before trying to use the user's phone.
