### PR TITLE
Automatically create Bolt PaymentMethod

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,3 +19,12 @@ Spree::AuthenticationMethod.find_or_create_by(provider: :bolt) do |authenticatio
   authentication_method.api_secret = SolidusBolt::BoltConfiguration.fetch.api_key
   authentication_method.active = true
 end
+
+if ENV['BOLT_API_KEY'] && ENV['BOLT_SIGNING_SECRET'] && ENV['BOLT_PUBLISHABLE_KEY']
+  SolidusBolt::PaymentMethod.create!(
+    type: 'SolidusBolt::PaymentMethod',
+    name: 'Bolt',
+    preference_source: 'bolt_credentials',
+    active: true
+  )
+end


### PR DESCRIPTION
We'd like a way for the gem to automatically create a Bolt PaymentMethod
when creating a new app or running seeds. This commit implements that,
provided the environment variables have been set.
