### PR TITLE
Create GetAccount endpoint

### DIFF
--- a/app/controllers/solidus_bolt/accounts_controller.rb
+++ b/app/controllers/solidus_bolt/accounts_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  class AccountsController < BaseController
+    def create
+      Spree::User.find_by!(email: params[:email])
+
+      head :ok
+    end
+  end
+end

--- a/app/controllers/solidus_bolt/base_controller.rb
+++ b/app/controllers/solidus_bolt/base_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module SolidusBolt
+  class BaseController < ::Spree::Api::BaseController
+    skip_before_action :authenticate_user
+    skip_before_action :verify_authenticity_token
+    before_action :verify_bolt_request
+
+    private
+
+    def verify_bolt_request
+      hmac_header = request.headers['X-Bolt-Hmac-Sha256']
+      signing_secret = SolidusBolt::BoltConfiguration.fetch&.signing_secret || ''
+      computed_hmac = Base64.encode64(OpenSSL::HMAC.digest("SHA256", signing_secret, params[:webhook].to_json)).strip
+
+      return render json: { error: 'Unauthorized request' }, status: :unauthorized unless hmac_header == computed_hmac
+    end
+  end
+end

--- a/app/controllers/solidus_bolt/webhooks_controller.rb
+++ b/app/controllers/solidus_bolt/webhooks_controller.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
-require 'base64'
-
 module SolidusBolt
-  class WebhooksController < ::Spree::Api::BaseController
-    skip_before_action :authenticate_user
-    skip_before_action :verify_authenticity_token
-    before_action :verify_bolt_request
-
+  class WebhooksController < BaseController
     def update
       ::SolidusBolt::Sorter.call(params)
 
@@ -16,16 +10,6 @@ module SolidusBolt
       error_message = e.to_s
       logger.error error_message
       render json: { error: error_message }, status: :unprocessable_entity
-    end
-
-    private
-
-    def verify_bolt_request
-      hmac_header = request.headers['X-Bolt-Hmac-Sha256']
-      signing_secret = SolidusBolt::BoltConfiguration.fetch&.signing_secret || ''
-      computed_hmac = Base64.encode64(OpenSSL::HMAC.digest("SHA256", signing_secret, params[:webhook].to_json)).strip
-
-      return render json: { error: 'Unauthorized request' }, status: :unauthorized unless hmac_header == computed_hmac
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Spree::Core::Engine.routes.draw do
   end
 
   post '/webhooks/bolt', to: '/solidus_bolt/webhooks#update'
+  post '/api/accounts/bolt', to: '/solidus_bolt/accounts#create'
 end

--- a/spec/requests/solidus_bolt/accounts_controller_spec.rb
+++ b/spec/requests/solidus_bolt/accounts_controller_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::AccountsController, type: :request do
+  describe '#create' do
+    subject(:call) do
+      post '/api/accounts/bolt', params: { email: email }, headers: { 'X-Bolt-Hmac-Sha256' => bolt_hash }, as: :json
+    end
+
+    let(:bolt_hash) { "yrjqA4qD4DoLUyH8aQZ1hVv75sJlCvULL7vI43PP8K4=" }
+    let(:user) { create(:user) }
+    let(:email) { user.email }
+
+    before { call }
+
+    context 'when valid' do
+      it 'has http status ok' do
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not valid' do
+      let(:email) { 'fake@email.com' }
+
+      it 'has http status not found' do
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'when not bolt request' do
+      let(:bolt_hash) { 'notBoltHash' }
+
+      it 'has http status unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As per Bolt's request we are creating a POST endpoint to which Bolt will
pass an email param, and we'll return either 200 or 404 based on whether
there is an account created with said email. The URL which they will
have to call is `/accounts/bolt`.

Since this controller shares a lot of points in common with the existing
WebhooksController, we are also creating a BaseController from which
both will inherit.

Fixes https://github.com/nebulab/solidus_bolt/issues/106