### PR TITLE
Fix params used in verify_bolt_request

### DIFF
--- a/app/controllers/solidus_bolt/accounts_controller.rb
+++ b/app/controllers/solidus_bolt/accounts_controller.rb
@@ -3,9 +3,15 @@
 module SolidusBolt
   class AccountsController < BaseController
     def create
-      Spree::User.find_by!(email: params[:email])
+      Spree::User.find_by!(email: permitted_params[:email])
 
       head :ok
+    end
+
+    private
+
+    def permitted_params
+      params[:account]
     end
   end
 end

--- a/app/controllers/solidus_bolt/base_controller.rb
+++ b/app/controllers/solidus_bolt/base_controller.rb
@@ -13,7 +13,7 @@ module SolidusBolt
     def verify_bolt_request
       hmac_header = request.headers['X-Bolt-Hmac-Sha256']
       signing_secret = SolidusBolt::BoltConfiguration.fetch&.signing_secret || ''
-      computed_hmac = Base64.encode64(OpenSSL::HMAC.digest("SHA256", signing_secret, params[:webhook].to_json)).strip
+      computed_hmac = Base64.encode64(OpenSSL::HMAC.digest("SHA256", signing_secret, permitted_params.to_json)).strip
 
       return render json: { error: 'Unauthorized request' }, status: :unauthorized unless hmac_header == computed_hmac
     end

--- a/app/controllers/solidus_bolt/webhooks_controller.rb
+++ b/app/controllers/solidus_bolt/webhooks_controller.rb
@@ -3,13 +3,19 @@
 module SolidusBolt
   class WebhooksController < BaseController
     def update
-      ::SolidusBolt::Sorter.call(params)
+      ::SolidusBolt::Sorter.call(permitted_params)
 
       render json: {}, status: :ok
     rescue StandardError => e
       error_message = e.to_s
       logger.error error_message
       render json: { error: error_message }, status: :unprocessable_entity
+    end
+
+    private
+
+    def permitted_params
+      params[:webhook]
     end
   end
 end

--- a/spec/requests/solidus_bolt/accounts_controller_spec.rb
+++ b/spec/requests/solidus_bolt/accounts_controller_spec.rb
@@ -5,23 +5,25 @@ require 'spec_helper'
 RSpec.describe SolidusBolt::AccountsController, type: :request do
   describe '#create' do
     subject(:call) do
-      post '/api/accounts/bolt', params: { email: email }, headers: { 'X-Bolt-Hmac-Sha256' => bolt_hash }, as: :json
+      post '/api/accounts/bolt', params: params, headers: { 'X-Bolt-Hmac-Sha256' => bolt_hash }, as: :json
     end
 
-    let(:bolt_hash) { "yrjqA4qD4DoLUyH8aQZ1hVv75sJlCvULL7vI43PP8K4=" }
-    let(:user) { create(:user) }
-    let(:email) { user.email }
+    let(:user) { create(:user, email: 'user@bolt.com') }
+    let(:params) { { account: { email: user.email } } }
 
     before { call }
 
     context 'when valid' do
+      let(:bolt_hash) { "+mDzzN0xsvB0UzO0NoAyMJYx/byPs++cccpR4tiEN0c=" }
+
       it 'has http status ok' do
         expect(response).to have_http_status(:ok)
       end
     end
 
     context 'when not valid' do
-      let(:email) { 'fake@email.com' }
+      let(:bolt_hash) { "CaAA/XZsO4wl6q/G7cyWY9KVcaWvieH7UWM6XoFcsmU=" }
+      let(:params) { { account: { email: 'fake@email.com' } } }
 
       it 'has http status not found' do
         expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
When we created in BaseController in a previous commit we forgot that it
called `params[:webhook]` to compute the signing secret, when in reality
the params will be different based on the controller called. Therefore
we are adding in this commit a private method to each controller that
will be called instead.

At the same time, we've updated the specs to pass params that more
accurately reflect actual params being passed.
